### PR TITLE
MTU for docker-compose

### DIFF
--- a/tasks/portal.yml
+++ b/tasks/portal.yml
@@ -100,6 +100,9 @@
       networks:
           frontend:
               driver: bridge
+              driver_opts:
+                  com.docker.network.driver.mtu: 1376
+
     dest: /opt/galaxy/docker-compose.yaml
     mode: '644'
 


### PR DESCRIPTION

Deployments with docker compose at CESNET require this MTU to work.

xrefs:
* https://docs.egi.eu/users/compute/cloud-container-compute/docker/#known-issues
* https://github.com/containerbuildsystem/osbs-box/issues/57
